### PR TITLE
feat: 커뮤니티 xml 마무리

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -13,20 +13,6 @@
         </DropdownSelection>
         <DialogSelection />
       </SelectionState>
-      <SelectionState runConfigName="AuthentiacationActivity">
-        <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2024-11-28T07:38:57.167292Z">
-          <Target type="DEFAULT_BOOT">
-            <handle>
-              <DeviceId pluginId="PhysicalDevice" identifier="serial=2b34de2d391c7ece" />
-            </handle>
-          </Target>
-        </DropdownSelection>
-        <DialogSelection />
-      </SelectionState>
-      <SelectionState runConfigName="MainActivity">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/app/src/main/res/drawable/community_write_complete_button.xml
+++ b/app/src/main/res/drawable/community_write_complete_button.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#009843" />
+    <corners android:radius="28dp" />
+</shape>

--- a/app/src/main/res/layout/activity_community_detail.xml
+++ b/app/src/main/res/layout/activity_community_detail.xml
@@ -5,6 +5,7 @@
     android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@color/white"
     tools:context=".presentation.community.posts.PostsActivity">
 
     <androidx.appcompat.widget.Toolbar
@@ -43,7 +44,7 @@
         android:id="@+id/community_detail_recyclerview"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_marginTop="32dp"
+        android:layout_marginTop="16dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/activity_community_write.xml
+++ b/app/src/main/res/layout/activity_community_write.xml
@@ -5,6 +5,7 @@
     android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@color/white"
     tools:context=".presentation.community.write.PostsWriteActivity">
 
     <androidx.appcompat.widget.Toolbar
@@ -18,6 +19,7 @@
 
         <TextView
             android:id="@+id/toolbar_title_textview"
+            style="@style/navigation"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
@@ -27,9 +29,15 @@
 
         <Button
             android:id="@+id/toolbar_done_button"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:layout_gravity="end"
+            android:background="@drawable/community_write_complete_button"
+            android:layout_width="70dp"
+            android:layout_height="35dp"
+            android:layout_gravity="end|center_vertical"
+            android:gravity="center"
+            android:textColor="@color/white"
+            android:textSize="12sp"
+            android:fontFamily="@font/pretendard_medium"
+            android:layout_marginEnd="12dp"
             android:text="완료" />
     </androidx.appcompat.widget.Toolbar>
 
@@ -37,10 +45,30 @@
         android:id="@+id/title_editext"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:background="@null"
         android:hint="제목"
+        android:textColorHint="#8C8C8C"
+        android:textColor="@color/black"
+        android:fontFamily="@font/pretendard_semi_bold"
+        android:textSize="20dp"
+        android:layout_marginStart="31dp"
+        android:layout_marginEnd="31dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/community_write_toolbar_title_textview" />
+
+    <View
+        android:id="@+id/line"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginVertical="8dp"
+        android:background="#A0A0A0"
+        android:layout_marginStart="31dp"
+        android:layout_marginEnd="31dp"
+        android:layout_marginTop="16dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/title_editext" />
 
     <EditText
         android:id="@+id/content_edittext"
@@ -49,9 +77,15 @@
         android:background="@null"
         android:gravity="top"
         android:hint="내용을 입력하세요."
+        android:textColorHint="#8C8C8C"
+        android:fontFamily="@font/pretendard_medium"
+        android:textSize="16dp"
+        android:layout_marginStart="31dp"
+        android:layout_marginEnd="31dp"
+        android:layout_marginTop="16dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/title_editext" />
+        app:layout_constraintTop_toBottomOf="@+id/line" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_post.xml
+++ b/app/src/main/res/layout/activity_post.xml
@@ -5,6 +5,7 @@
     android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@color/white"
     tools:context=".presentation.community.comments.CommentsActivity">
 
     <androidx.appcompat.widget.Toolbar
@@ -12,12 +13,14 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:navigationIcon="@drawable/uil_arrow_left">
 
         <TextView
             android:id="@+id/toolbar_title_textview"
+            style="@style/navigation"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
@@ -35,10 +38,10 @@
 
         <ImageView
             android:id="@+id/app_icon_imageview"
-            android:layout_width="50dp"
-            android:layout_height="50dp"
-            android:layout_marginStart="31dp"
-            android:layout_marginTop="31dp"
+            android:layout_width="61dp"
+            android:layout_height="53dp"
+            android:layout_marginStart="24dp"
+            android:layout_marginTop="28dp"
             android:src="@drawable/cookie_time_icon"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
@@ -47,7 +50,10 @@
             android:id="@id/nickname_textview"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:fontFamily="@font/pretendard_bold"
             android:text="닉네임"
+            android:textSize="20dp"
             app:layout_constraintStart_toEndOf="@id/app_icon_imageview"
             app:layout_constraintTop_toTopOf="@id/app_icon_imageview" />
 
@@ -55,7 +61,11 @@
             android:id="@+id/timestamp_textview"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:fontFamily="@font/pretendard_medium"
             android:text="11/24 21:37"
+            android:textColor="#8C8C8C"
+            android:textSize="16dp"
             app:layout_constraintBottom_toBottomOf="@id/app_icon_imageview"
             app:layout_constraintStart_toEndOf="@id/app_icon_imageview" />
 
@@ -70,23 +80,43 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="31dp"
-                android:layout_marginTop="22dp"
+                android:layout_marginTop="16dp"
                 android:layout_marginEnd="31dp"
+                android:fontFamily="@font/pretendard_bold"
                 android:text="제목"
+                android:textSize="24dp"
                 app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
                 android:id="@+id/content_textview"
                 android:layout_width="0dp"
-                android:layout_height="0dp"
+                android:layout_height="wrap_content"
                 android:layout_marginTop="10dp"
+                android:fontFamily="@font/pretendard_regular"
+                android:lineSpacingExtra="4dp"
                 android:text="게시글 내용 어쩌고 저쩌고 어쩌고 저쩌고 줄글 블라블라... 눈이 펑펑.. 게시글 내용 어쩌고 저쩌고 어쩌고 저쩌고 줄글 블라블라... 눈이 펑펑.. 게시글 내용 어쩌고 저쩌고 어쩌고 저쩌고 줄글 블라블라... 눈이 펑펑.. 게시글 내용 어쩌고 저쩌고 어쩌고 저쩌고 줄글 블라블라... 눈이 펑펑.."
+                android:textSize="16dp"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="@id/title_textview"
+                app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintStart_toStartOf="@id/title_textview"
-                app:layout_constraintTop_toBottomOf="@id/title_textview" />
+                app:layout_constraintTop_toBottomOf="@id/title_textview"
+                app:layout_constraintVertical_bias="0.0" />
+
+            <View
+                android:id="@+id/line"
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_marginVertical="8dp"
+                android:layout_marginTop="20dp"
+                android:background="#A0A0A0"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/content_textview" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
 
@@ -98,6 +128,8 @@
         android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/post_viewgroup" />
+        app:layout_constraintTop_toBottomOf="@id/post_viewgroup"
+        app:layout_constraintVertical_bias="0.0" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_comment.xml
+++ b/app/src/main/res/layout/item_comment.xml
@@ -20,6 +20,8 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
         android:text="닉네임"
+        android:textSize="16sp"
+        android:fontFamily="@font/pretendard_bold"
         app:layout_constraintBottom_toBottomOf="@id/icon_imageview"
         app:layout_constraintStart_toEndOf="@+id/icon_imageview"
         app:layout_constraintTop_toTopOf="@+id/icon_imageview" />
@@ -29,7 +31,9 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
+        android:textSize="16sp"
         android:text="댓글 내용 어쩌구 저쩌고"
+        android:fontFamily="@font/pretendard_regular"
         app:layout_constraintStart_toStartOf="@+id/icon_imageview"
         app:layout_constraintTop_toBottomOf="@+id/icon_imageview" />
 
@@ -37,8 +41,21 @@
         android:id="@+id/timestamp_textview"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:textSize="16sp"
+        android:textColor="#8C8C8C"
+        android:fontFamily="@font/pretendard_regular"
         android:text="11/24 21:58"
         app:layout_constraintStart_toStartOf="@id/content_textview"
-        app:layout_constraintTop_toBottomOf="@+id/content_textview" />
+        app:layout_constraintTop_toBottomOf="@+id/content_textview"/>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginStart="31dp"
+        android:layout_marginEnd="31dp"
+        android:background="#A0A0A0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/timestamp_textview"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_community_detail.xml
+++ b/app/src/main/res/layout/item_community_detail.xml
@@ -6,6 +6,7 @@
 
     <TextView
         android:id="@+id/title_textview"
+        style="@style/community_detail_title_community_viewholder"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="13dp"
@@ -16,6 +17,7 @@
 
     <TextView
         android:id="@+id/content_textview"
+        style="@style/community_detail_info_community_viewholder"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="오늘 용아맥 무대인사 2시 다녀왔는데 진짜 분위기 좋고 팬서비스도..."
@@ -34,6 +36,7 @@
 
     <TextView
         android:id="@+id/comment_number"
+        style="@style/community_detail_comment_community_viewholder"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="2dp"
@@ -45,6 +48,7 @@
 
     <TextView
         android:id="@+id/posted_time_textview"
+        style="@style/community_detail_time_community_viewholder"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text=" | N분 전"
@@ -54,11 +58,20 @@
 
     <TextView
         android:id="@+id/nickname_textview"
+        style="@style/community_detail_nickname_community_viewholder"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text=" | 하이용"
         app:layout_constraintBottom_toBottomOf="@+id/posted_time_textview"
         app:layout_constraintStart_toEndOf="@+id/posted_time_textview"
         app:layout_constraintTop_toTopOf="@+id/posted_time_textview" />
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginTop="16dp"
+        android:background="#A0A0A0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/nickname_textview" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/style.xml
+++ b/app/src/main/res/values/style.xml
@@ -3,7 +3,7 @@
     <!-- styles.xml -->
     <style name="navigation">
         <item name="android:textSize">20sp</item>
-        <item name="android:fontFamily">@font/pretendard_regular</item>
+        <item name="android:fontFamily">@font/pretendard_bold</item>
         <item name="android:textColor">#000000</item>
     </style>
 
@@ -42,6 +42,41 @@
         <item name="android:letterSpacing">0.04</item>
         <item name="android:textColorHint">#ABFFFFFF</item>
         <item name="android:fontFamily">@font/pretendard_regular</item>
+    </style>
+
+    <style name="community_detail_title_community_viewholder">
+        <item name="android:textSize">16sp</item>
+        <item name="fontFamily">@font/pretendard_bold</item>
+        <item name="android:letterSpacing">0.04</item>
+        <item name="android:textColor">@color/black</item>
+    </style>
+
+    <style name="community_detail_info_community_viewholder">
+        <item name="android:textSize">12sp</item>
+        <item name="fontFamily">@font/pretendard_regular</item>
+        <item name="android:letterSpacing">0.04</item>
+        <item name="android:textColor">@color/black</item>
+    </style>
+
+    <style name="community_detail_comment_community_viewholder">
+        <item name="android:textSize">12sp</item>
+        <item name="fontFamily">@font/pretendard_regular</item>
+        <item name="android:letterSpacing">0.04</item>
+        <item name="android:textColor">#8C8C8C</item>
+    </style>
+
+    <style name="community_detail_time_community_viewholder">
+        <item name="android:textSize">12sp</item>
+        <item name="fontFamily">@font/pretendard_regular</item>
+        <item name="android:letterSpacing">0.04</item>
+        <item name="android:textColor">#8C8C8C</item>
+    </style>
+
+    <style name="community_detail_nickname_community_viewholder">
+        <item name="android:textSize">12sp</item>
+        <item name="fontFamily">@font/pretendard_regular</item>
+        <item name="android:letterSpacing">0.04</item>
+        <item name="android:textColor">#8C8C8C</item>
     </style>
 
 </resources>


### PR DESCRIPTION
# 쿠키타임 Pull Request

## 이슈 연결

- Resolved: #

## 설명
커뮤니티 관련 xml 세부 작업 완료했습니당

목록에서 들어간 개별 게시글에서 내용 부분과 댓글을 구분 짓는 line과 첫 댓글 item 부분의 간격이 고정되어있어서 수정이 필요합니다.. 리사이클러뷰 관련인 듯 하여 자바 코드 상에서 해결해야할 듯 한데, 필요하다면 xml 상에서 수정 봐야할 것 같아요

- 개별 커뮤니티의 글 목록의 item 수정
- 글쓰기 화면 수정
    - 시연 때 제목 길이가 두 줄 이상 넘지 않도록 해야할 것 같습니다 ㅎㅎ
- 개별 게시글에 달리는 item 수정
- 댓글이 하나도 없을 때 xml은 어디에 띄워야할지 모르겠어서 우선.. 댓글 item만 수정 본 상태입니다
- 댓글 입력하는 EditText가 없길래 리사이클러뷰 밖에 해주어야 할 것 같아서 그 부분도 남겨둔 상태입니닷

## 첨부 화면 영상

> 안드로이드 에뮬레이터 동작 화면 영상을 첨부해주세요.
