### PR TITLE
feat : 마이페이지 레이아웃 마감

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -2,9 +2,9 @@
 <project version="4">
   <component name="deploymentTargetSelector">
     <selectionStates>
-      <SelectionState runConfigName="app">
+      <SelectionState runConfigName="AuthentiacationActivity">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2024-11-24T06:38:41.143229Z">
+        <DropdownSelection timestamp="2024-12-05T07:11:59.201769Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="LocalEmulator" identifier="path=/Users/yewon/.android/avd/Medium_Phone_API_35.avd" />

--- a/app/src/main/java/com/ssuclass/cookietime/presentation/mypage/MyPageFragment.java
+++ b/app/src/main/java/com/ssuclass/cookietime/presentation/mypage/MyPageFragment.java
@@ -117,7 +117,9 @@ public class MyPageFragment extends Fragment {
                 .get()
                 .addOnSuccessListener(queryDocumentSnapshots -> {
                     int watchedMoviesCount = queryDocumentSnapshots.size();
-                    binding.badgeCountTextview.setText("지금까지 총" + watchedMoviesCount + "개의 쿠키 인증 뱃지를 획득했어요!");
+                    binding.badgeCountTextviewFront.setText("지금까지 총");
+                    binding.badgeCountTextviewNumber.setText(watchedMoviesCount);
+                    binding.badgeCountTextviewBack.setText("개의 쿠키 인증 뱃지를 획득했어요!");
                 })
                 .addOnFailureListener(e -> {
                     ToastHelper.showToast(getContext(), "데이터를 불러오는데 실패했습니다.");

--- a/app/src/main/res/drawable/mypage_badge_count_background.xml
+++ b/app/src/main/res/drawable/mypage_badge_count_background.xml
@@ -1,0 +1,25 @@
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="#40000000" />
+            <corners
+                android:bottomLeftRadius="12dp"
+                android:bottomRightRadius="12dp"
+                android:topLeftRadius="12dp"
+                android:topRightRadius="12dp" />
+        </shape>
+    </item>
+
+    <item android:top="4dp" android:left="0dp" android:right="4dp" android:bottom="0dp">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/white" />
+            <corners
+                android:bottomLeftRadius="12dp"
+                android:bottomRightRadius="12dp"
+                android:topLeftRadius="12dp"
+                android:topRightRadius="12dp" />
+        </shape>
+    </item>
+
+</layer-list>

--- a/app/src/main/res/layout/activity_change_nickname.xml
+++ b/app/src/main/res/layout/activity_change_nickname.xml
@@ -18,6 +18,7 @@
 
         <TextView
             android:id="@+id/toolbar_title_textview"
+            style="@style/navigation"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
@@ -30,6 +31,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="24dp"
         android:layout_marginTop="29dp"
+        android:fontFamily="@font/pretendard_semi_bold"
         android:text="커뮤니티에서 사용할 닉네임을 입력해주세요"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/toolbar" />
@@ -43,11 +45,11 @@
         android:layout_marginEnd="8dp"
         android:background="@drawable/edit_text_background"
         android:fontFamily="@font/pretendard_regular"
-        android:hint="닉네임을 입력해주세요."
-        android:padding="12dp"
+        android:hint="변경할 닉네임을 입력해주세요."
+        android:padding="16sp"
         android:textColor="#000000"
         android:textColorHint="#A0A0A0"
-        android:textSize="16dp"
+        android:textSize="12sp"
         app:layout_constraintEnd_toStartOf="@id/change_button"
         app:layout_constraintStart_toStartOf="@id/info_change_nickname_textview"
         app:layout_constraintTop_toBottomOf="@id/info_change_nickname_textview" />
@@ -59,6 +61,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="17dp"
         android:layout_marginEnd="24dp"
+        android:background="@drawable/button_rounded"
         android:text="변경"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/info_change_nickname_textview" />

--- a/app/src/main/res/layout/activity_change_password.xml
+++ b/app/src/main/res/layout/activity_change_password.xml
@@ -18,6 +18,7 @@
 
         <TextView
             android:id="@+id/toolbar_title_textview"
+            style="@style/navigation"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
@@ -30,7 +31,8 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="24dp"
         android:layout_marginTop="29dp"
-        android:text="비밀번호를 입력해주세요"
+        android:fontFamily="@font/pretendard_semi_bold"
+        android:text="현재 비밀번호와 변경할 비밀번호를 입력해주세요"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/toolbar" />
 
@@ -44,13 +46,13 @@
         android:background="@drawable/edit_text_background"
         android:fontFamily="@font/pretendard_regular"
         android:hint="현재 비밀번호를 입력해주세요."
-        android:padding="12dp"
+        android:padding="16dp"
         android:textColor="#000000"
         android:textColorHint="#A0A0A0"
-        android:textSize="16dp"
+        android:textSize="12sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/toolbar" />
+        app:layout_constraintTop_toBottomOf="@+id/info_change_password_textview" />
 
 
     <EditText
@@ -62,11 +64,11 @@
         android:layout_marginEnd="24dp"
         android:background="@drawable/edit_text_background"
         android:fontFamily="@font/pretendard_regular"
-        android:hint="비밀번호를 입력해주세요."
-        android:padding="12dp"
+        android:hint="변경할 비밀번호를 입력해주세요."
+        android:padding="16dp"
         android:textColor="#000000"
         android:textColorHint="#A0A0A0"
-        android:textSize="16dp"
+        android:textSize="12sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/input_current_password_editext" />
@@ -79,7 +81,8 @@
         android:layout_marginStart="24dp"
         android:layout_marginTop="17dp"
         android:layout_marginEnd="24dp"
-        android:text="변경"
+        android:background="@drawable/button_rounded"
+        android:text="비밀번호 변경"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/input_change_password_editext" />

--- a/app/src/main/res/layout/activity_community_detail.xml
+++ b/app/src/main/res/layout/activity_community_detail.xml
@@ -56,6 +56,8 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="34dp"
         android:text="글쓰기"
+        android:background="@drawable/button_rounded"
+        android:textColor="@color/white"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />

--- a/app/src/main/res/layout/activity_friend_list.xml
+++ b/app/src/main/res/layout/activity_friend_list.xml
@@ -18,6 +18,7 @@
 
         <TextView
             android:id="@+id/toolbar_title_textview"
+            style="@style/navigation"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"

--- a/app/src/main/res/layout/fragment_my_page.xml
+++ b/app/src/main/res/layout/fragment_my_page.xml
@@ -28,6 +28,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
+            style="@style/navigation"
             android:text="마이페이지" />
     </com.google.android.material.appbar.MaterialToolbar>
 
@@ -68,12 +69,17 @@
                     android:id="@+id/profile_nickname"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="닉네임님 안녕하세요!" />
+                    android:fontFamily="@font/pretendard_semi_bold"
+                    android:text="닉네임님 안녕하세요!"
+                    android:textSize="24sp" />
 
                 <TextView
                     android:id="@+id/profile_username"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:textSize="16sp"
+                    android:fontFamily="@font/pretendard_medium"
+                    android:textColor="#8C8C8C"
                     android:text="사용자이름" />
 
             </LinearLayout>
@@ -83,10 +89,10 @@
         <LinearLayout
             android:id="@+id/badge_counter_banner_viewgroup"
             android:layout_width="0dp"
-            android:layout_height="52dp"
+            android:layout_height="60dp"
             android:layout_marginStart="30dp"
             android:layout_marginEnd="30dp"
-            android:background="@color/white"
+            android:background="@drawable/mypage_badge_count_background"
             android:orientation="horizontal"
             app:layout_constraintBottom_toBottomOf="@id/profile_viewgroup"
             app:layout_constraintEnd_toEndOf="parent"
@@ -94,11 +100,34 @@
             app:layout_constraintTop_toBottomOf="@id/profile_banner_viewgroup">
 
             <TextView
-                android:id="@+id/badge_count_textview"
-                android:layout_width="match_parent"
+                android:id="@+id/badge_count_textview_front"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
-                android:text="지금까지 총 23개의 쿠키 인증 뱃지를 획득했어요!" />
+                android:textSize="12sp"
+                android:fontFamily="@font/pretendard_medium"
+                android:paddingStart="42dp"
+                android:paddingEnd="5dp"
+                android:text="지금까지 총" />
+            <TextView
+                android:id="@+id/badge_count_textview_number"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:paddingEnd="3dp"
+                android:textSize="28sp"
+                android:textColor="#009843"
+                android:fontFamily="@font/pretendard_bold"
+                android:text="23" />
+
+            <TextView
+                android:id="@+id/badge_count_textview_back"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="12sp"
+                android:fontFamily="@font/pretendard_medium"
+                android:layout_gravity="center"
+                android:text="개의 쿠키 인증 뱃지를 획득했어요!" />
         </LinearLayout>
 
 
@@ -123,6 +152,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="30dp"
+                style="@style/mypage_content"
                 android:text="친구 목록"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
@@ -152,6 +182,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="30dp"
+                style="@style/mypage_content"
                 android:text="닉네임 변경"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
@@ -181,6 +212,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="30dp"
+                style="@style/mypage_content"
                 android:text="비밀번호 변경"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
@@ -210,6 +242,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="30dp"
+                style="@style/mypage_content"
                 android:text="로그아웃"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values/style.xml
+++ b/app/src/main/res/values/style.xml
@@ -40,7 +40,7 @@
         <item name="android:textSize">16sp</item>
         <item name="android:editTextBackground">@null</item>
         <item name="android:letterSpacing">0.04</item>
-        <item name="android:textColorHint">#ABFFFFFF</item>
+        <item name="android:textColorHint">@android:color/white</item>
         <item name="android:fontFamily">@font/pretendard_regular</item>
     </style>
 
@@ -77,6 +77,13 @@
         <item name="fontFamily">@font/pretendard_regular</item>
         <item name="android:letterSpacing">0.04</item>
         <item name="android:textColor">#8C8C8C</item>
+    </style>
+
+    <style name="mypage_content">
+        <item name="android:textSize">16sp</item>
+        <item name="fontFamily">@font/pretendard_semi_bold</item>
+        <item name="android:letterSpacing">0.04</item>
+        <item name="android:textColor">@color/black</item>
     </style>
 
 </resources>


### PR DESCRIPTION
# 쿠키타임 Pull Request

## 이슈 연결

- Resolved: #

## 설명
마이페이지 관련 xml 세부 작업 완료했습니당
친구 목록에서 친구 추가하는 화면으로 넘어가는 버튼이 없어서 우선 친구 목록 관련 xml은 추가로 작업 안했습니다 (친구목록 없애는 쪽으로 지난번에 얘기가 나온 것도 있구..)

- 마이페이지 메인 화면에 쿠키 개수 띄워주는 영역에 텍스트 크기가 각각 달라서 세 부분으로 쪼개서 자바 코드에 id 반영해서 수정했습니당
    - “지금까지 총” 부분 : `badge_count_textview_front`
    - 쿠키 개수 부분 : `badge_count_textview_number`
    - “개의 쿠키 인증 뱃지를 획득했어요!” 부분 : `badge_count_textview_back`
- 마이페이지 항목들 텍스트 반영
- 닉네임, 비밀번호 변경 페이지 레이아웃 세부 조정

## 첨부 화면 영상

> 안드로이드 에뮬레이터 동작 화면 영상을 첨부해주세요.
